### PR TITLE
Initial client-stats support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ danb.eth: 0xBe5Bd61fd37444290913Eff8f5dfF8C4D0d7A093 (NFTs welcome)
 
 # Version
 
-This is eth-docker v1.2.1
+This is eth-docker v1.2.2

--- a/default.env
+++ b/default.env
@@ -43,6 +43,10 @@ TEKU_RAPID_SYNC=
 # or could just be an eth2/beacon Infura project URL for Teku or Lighthouse "validator only" setups. Not in use for Prysm or Nimbus.
 CC_NODE=http://consensus:5052
 
+# Beaconcha.in API key for sending client stats from Prysm. Used with prysm-stats.yml
+# Specify as just the API key or as APIKEY/MACHINENAME
+BEACON_STATS_API=
+
 # P2P ports you will forward to your staking node. Adjust here if you are
 # going to use something other than defaults.
 EC_P2P_PORT=30303

--- a/lh-stats.yml
+++ b/lh-stats.yml
@@ -1,0 +1,13 @@
+# Send client stats to beaconcha.in service
+version: "3.4"
+services:
+  consensus:
+    command:
+      - --monitoring-endpoint
+      - https://beaconcha.in/api/v1/stats/${BEACON_STATS_API}
+  validator:
+    expose:
+      - 8081/tcp
+    command:
+      - --monitoring-endpoint
+      - https://beaconcha.in/api/v1/stats/${BEACON_STATS_API}

--- a/lighthouse/docker-entrypoint.sh
+++ b/lighthouse/docker-entrypoint.sh
@@ -11,11 +11,7 @@ if [ "$(id -u)" = '0' ]; then
     chown -R lhvalidator:lhvalidator /var/lib/lighthouse
     exec gosu lhvalidator "$BASH_SOURCE" "$@"
   else
-    echo "Could not determine whether beacon or validator client."
-    echo "This is a bug, please report it at https://github.com/eth2-educators/eth2-docker/,"
-    echo "and thank you."
-    echo "Failed to match on" $2
-    exit
+    echo "Could not determine whether consensus or validator client, running as-is."
   fi
 fi
 

--- a/prysm-stats.yml
+++ b/prysm-stats.yml
@@ -1,0 +1,31 @@
+# Send client stats to beaconcha.in service
+version: "3.4"
+services:
+  consensus:
+    expose:
+      - 8080/tcp
+    command:
+      - --monitoring-host
+      - 0.0.0.0
+  validator:
+    expose:
+      - 8081/tcp
+    command:
+      - --monitoring-host
+      - 0.0.0.0
+  client-stats:
+    image: prysm-consensus:local
+    volumes:
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+    entrypoint:
+      - client-stats 
+      - --validator-metrics-url
+      - http://validator:8081/metrics
+      - --beacon-node-metrics-url
+      - http://consensus:8080/metrics
+      - --clientstats-api-url
+      - https://beaconcha.in/api/v1/stats/${BEACON_STATS_API}
+  eth:
+    depends_on:
+      - client-stats

--- a/prysm/Dockerfile.source
+++ b/prysm/Dockerfile.source
@@ -9,7 +9,7 @@ ARG BUILD_TARGET
 RUN apt-get update && apt-get install -y cmake libtinfo5 libgmp-dev npm && npm install -g @bazel/bazelisk && bazel version
 
 WORKDIR /go/src
-RUN bash -c "git clone https://github.com/prysmaticlabs/prysm.git && cd prysm && git config advice.detachedHead false && git fetch --all --tags && git checkout ${BUILD_TARGET} && bazel build --config=release //beacon-chain:beacon-chain && bazel build --config=release //validator:validator && bazel build --config=release //slasher:slasher"
+RUN bash -c "git clone https://github.com/prysmaticlabs/prysm.git && cd prysm && git config advice.detachedHead false && git fetch --all --tags && git checkout ${BUILD_TARGET} && bazel build --config=release //beacon-chain:beacon-chain && bazel build --config=release //validator:validator && bazel build --config=release //slasher:slasher && bazel build --config=release //cmd/client-stats:client-stats"
 
 # Pull all binaries into a second stage deploy debian container
 FROM debian:buster-slim as consensus
@@ -46,6 +46,7 @@ RUN mkdir -p /var/lib/prysm && chown ${USER}:${USER} /var/lib/prysm && chmod 700
 COPY --from=builder /go/src/prysm/bazel-bin/cmd/beacon-chain/beacon-chain_/beacon-chain /usr/local/bin/
 COPY --from=builder /go/src/prysm/bazel-bin/cmd/validator/validator_/validator /usr/local/bin/
 COPY --from=builder /go/src/prysm/bazel-bin/cmd/slasher/slasher_/slasher /usr/local/bin/
+COPY --from=builder /go/src/prysm/bazel-bin/cmd/client-stats/client-stats_/client-stats /usr/local/bin/
 COPY ./docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh","beacon-chain"]

--- a/teku-base.yml
+++ b/teku-base.yml
@@ -9,6 +9,7 @@ services:
         - DOCKER_TAG=${TEKU_DOCKER_TAG}
       dockerfile: ${TEKU_DOCKERFILE}
     image: teku:local
+    stop_grace_period: 1m
     volumes:
       - teku-data:/var/lib/teku
       - /etc/timezone:/etc/timezone:ro


### PR DESCRIPTION
For Prysm and Lighthouse. Prysm source-build only until official docker hub images have been released.