### PR TITLE
Fix prysm validator import

### DIFF
--- a/prysm-base.yml
+++ b/prysm-base.yml
@@ -120,10 +120,8 @@ services:
       - /var/lib/prysm
       - accounts
       - import
-      - --wallet-dir
-      - /var/lib/prysm/
-      - --keys-dir
-      - /val_keys
+      - --wallet-dir=/var/lib/prysm
+      - --keys-dir=/val_keys
       - --${NETWORK}
   validator-exit:
     restart: "no"


### PR DESCRIPTION
Perhaps this is an upstream bug in prysm, but when I attempted to add new validators today, this is what I encountered:

```
zgrannan@validate:~/eth2-docker$ sudo docker-compose run --rm validator-import
WARNING: The ETH1_NODE variable is not set. Defaulting to a blank string.
WARNING: The ETH1_FALLBACK_NODE1 variable is not set. Defaulting to a blank string.
WARNING: The ETH1_FALLBACK_NODE2 variable is not set. Defaulting to a blank string.
WARNING: The ETH1_PORT variable is not set. Defaulting to a blank string.          
WARNING: The ETH1_RPC_PORT variable is not set. Defaulting to a blank string.      
WARNING: The ETH1_WS_PORT variable is not set. Defaulting to a blank string.                  
WARNING: The ETH1_NETWORK variable is not set. Defaulting to a blank string. 
Will you import keys via the Web UI? (y/n) n                                
Continuing to key import                                                    
                                            
                              
[2021-07-26 22:39:08] ERROR main: unrecognized argument: /var/lib/prysm/
```

Looking at the [prysm docs](https://docs.prylabs.network/docs/wallet/nondeterministic/), it appears they prefer parameters using the format `a=b`, like:

```./prysm.sh validator wallet create --wallet-dir=$HOME/nonhdwallet --wallet-password-file=/path/to/password.txt --keymanager-kind=imported```

Anyways, this PR includes a change that makes this work for me. There may be other lurking issues with arguments being passed to prysm however, or maybe this is somehow just a quirk on my machine.