### PR TITLE
Added note about Altair fork

### DIFF
--- a/default.env
+++ b/default.env
@@ -108,6 +108,11 @@ LH_DOCKER_TAG=latest
 LH_DOCKERFILE=Dockerfile.binary
 
 # Prysm
+# If running on Prater testnet you need to use v2.0.0-rc.1 because of the Altair fork.
+# https://github.com/prysmaticlabs/prysm/releases/tag/v2.0.0-rc.1
+# PRYSM_SRC_BUILD_TARGET=v2.0.0-rc.1
+# PRYSM_DOCKER_TAG=v2.0.0-rc.1
+# PRYSM_DOCKERFILE=Dockerfile.binary
 PRYSM_SRC_BUILD_TARGET=$(git describe --tags $(git rev-list --tags --max-count=1))
 PRYSM_DOCKER_TAG=stable
 PRYSM_DOCKERFILE=Dockerfile.binary


### PR DESCRIPTION
The latest stable version of Prysm does not work with the Prater testnet. Need to use the latest unstable release.

https://github.com/prysmaticlabs/prysm/releases/tag/v2.0.0-rc.1

But I'm not sure if this should go in the docs or here.