### PR TITLE
Support new beaconcha.in stats endpoint - separate consensus and validator

### DIFF
--- a/lh-stats-consensus.yml
+++ b/lh-stats-consensus.yml
@@ -4,4 +4,4 @@ services:
   consensus:
     command:
       - --monitoring-endpoint
-      - https://beaconcha.in/api/v1/stats/${BEACON_STATS_API}
+      - https://beaconcha.in/api/v1/client/metrics?apikey=${BEACON_STATS_API}&machine=${BEACON_STATS_MACHINE}

--- a/lh-stats-validator.yml
+++ b/lh-stats-validator.yml
@@ -4,4 +4,4 @@ services:
   validator:
     command:
       - --monitoring-endpoint
-      - https://beaconcha.in/api/v1/stats/${BEACON_STATS_API}
+      - https://beaconcha.in/api/v1/client/metrics?apikey=${BEACON_STATS_API}&machine=${BEACON_STATS_MACHINE}


### PR DESCRIPTION
Carbon copy of PR #273 for the separate lh-stats-consensus.yml and lh-stats-validator.yml components of the stack.